### PR TITLE
Add explorer urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # RPC API providers list
-This repo allows for an easy management of the RPC API providers list.
+This repo contains community-maintained lists for accessing the LoT network.
+
+- `list.txt` — list of public RPC API endpoints used by web3 apps.
+- `explorer_urls_list.txt` — list of public block explorer URLs.
+
 The endpoints provide public remote access for web3 wallets and dApps to the LoT network and are maintained by the community members. 
 
 Due to the LoT decentralized nature this repo cannot embrace the ultimate list of the endpoints available, 
@@ -9,5 +13,3 @@ providing just short number of well tested ones.
 For the network maintainers willing to add new RPC API endpoints to the list Pull Request is required. 
 
 [How to set up WSS RPC API endpoint for remote connections](https://github.com/3Dpass/3DP/wiki/Set-up-WSS-for-Remote-Connections)
-
-

--- a/explorer_urls_list.txt
+++ b/explorer_urls_list.txt
@@ -1,0 +1,1 @@
+https://scan.p3d.top/

--- a/list.txt
+++ b/list.txt
@@ -1,3 +1,2 @@
 wss://rpc.3dpass.org
 wss://rpc.p3d.top
-https://rpc.p3d.top


### PR DESCRIPTION
Adds a list of available block explorer urls so they can be used by web3 apps